### PR TITLE
Output dimple mtz to main output directory

### DIFF
--- a/src/metal_id/metal_id.py
+++ b/src/metal_id/metal_id.py
@@ -9,6 +9,7 @@ from metal_id_helpers import (
     mtz_exists,
     run_dimple,
     generate_coot_viewer_script,
+    are_pdbs_similar,
 )
 from scaling import scale_data
 from calc_map import calc_double_diff_maps
@@ -135,9 +136,27 @@ logging.info(f"\nCaptured output from dimple: \n {dimple_output.stdout}")
 pdb_below = dimple_dir_below / "final.pdb"
 pha_below = dimple_dir_below / "anode.pha"
 
+# Check pdb files
+logging.info(
+    f"\n### Checking pdb files for similarity ###\nFiles: {pdb_above}, {pdb_below}\n"
+)
+pdbs_are_similar = are_pdbs_similar(
+    pdb_above,
+    pdb_below,
+)
+
+if not pdbs_are_similar:
+    logging.error("PDB files output by dimple not similar enough, terminating metal_id")
+    sys.exit(1)
+
+logging.info("PDB files are similar enough, continuing with metal_id")
+dimple_mtz = dimple_dir_above / "final.mtz"
+logging.info("Copying dimple mtz to output directory")
+shutil.copy(dimple_mtz, output_dir / "dimple_final.mtz")
+
 logging.info("### Calculating map of element location ###\n")
 files_out = calc_double_diff_maps(
-    pdb_above, pdb_below, pha_above, pha_below, output_dir, peak_threshold, max_peaks
+    pdb_above, pha_above, pha_below, output_dir, peak_threshold, max_peaks
 )
 
 if files_out:

--- a/src/metal_id/metal_id.py
+++ b/src/metal_id/metal_id.py
@@ -150,11 +150,16 @@ if not pdbs_are_similar:
     sys.exit(1)
 
 logging.info("PDB files are similar enough, continuing with metal_id")
-dimple_mtz = dimple_dir_above / "final.mtz"
-logging.info("Copying dimple mtz to output directory")
-shutil.copy(dimple_mtz, output_dir / "dimple_final.mtz")
+dimple_above_mtz = dimple_dir_above / "final.mtz"
+logging.info("Copying dimple mtzs to output directory")
+for dimple_dir, output_filename in [
+    (dimple_dir_above, "dimple_above.mtz"),
+    (dimple_dir_below, "dimple_below.mtz"),
+]:
+    shutil.copy(dimple_dir / "final.mtz", output_dir / output_filename)
+    logging.info(f"Copied {dimple_dir / 'final.mtz'} to {output_dir / output_filename}")
 
-logging.info("### Calculating map of element location ###\n")
+logging.info("\n### Calculating map of element location ###\n")
 files_out = calc_double_diff_maps(
     pdb_above, pha_above, pha_below, output_dir, peak_threshold, max_peaks
 )


### PR DESCRIPTION
At the request of users/I23, adds dimple mtz files to the main output of metal_id

Moves around the code for checking pdb similarity to avoid making the calculate maps step responsible for copying the dimple mtz file.

Also adds a trivial fix to the logging whereby the calc_maps function was writing out to the file instead of using the logger, which resulted in some of the coot output being appended to the end of the log file. 